### PR TITLE
Increasing support for RedHat-based OS family

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# bacula-formula
+Bacula Saltstack Formula

--- a/bacula/client.sls
+++ b/bacula/client.sls
@@ -6,6 +6,27 @@ bacula-fd:
   service.running:
     - enable: True
 
+bacula-working-directory:
+  file.directory:
+    - name: {{ bacula.get('lookup').get('bacula:client:config:FileDaemon:WorkingDirectory', '/var/lib/bacula') }}
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+    - require_in:
+      - service: bacula-fd
+
+bacula-pid-directory:
+  file.directory:
+    - name: {{ bacula.get('lookup').get('bacula:client:config:FileDaemon:Pid Directory', '/var/run/bacula') }}
+    - user: root
+    - group: root
+    - mode: 755
+    - makedirs: True
+    - require_in:
+      - service: bacula-fd
+
+
 {% if bacula.get('client').get('encryption', False) %}
 bacula-fd-key-pair:
   file.managed:

--- a/bacula/map.jinja
+++ b/bacula/map.jinja
@@ -13,6 +13,12 @@ override packages to mysql versions (bacula-...-mysql) and set dbtype = mysql. #
       'encryption': True
     },
     'RedHat': {
+      'common_pkgs': ['bacula-common'],
+      'director_pkgs': ['bacula-director'],
+      'storage_pkgs': ['bacula-storage'],
+      'console_pkgs': ['bacula-console'],
+      'client_pkgs': ['bacula-client', 'bacula-director'],
+
     },
   }, default='Debian' ),
 }, merge=True) %}


### PR DESCRIPTION
This PR updates the RedHat `map.jinja` to include the default packages for bacula installation.
Additionally, `Working Directory` and `PidDirectory` needed to be created, so added the functionality for `file.managed` on those in the bacula.client state